### PR TITLE
Add screenorientation for Windows Moblile/CE device to ATS

### DIFF
--- a/auto/feature_def/auto_common_spec/build.yml
+++ b/auto/feature_def/auto_common_spec/build.yml
@@ -50,7 +50,7 @@ android:
 wm:
   #use_shared_runtime: yes
   #sdk: MC3000c50b (ARMV4I)
-  extensions: ["barcode", "instrumentation"]
+  extensions: ["barcode", "screenorientation", "instrumentation"]
 #capabilities:
 #- non_motorola_device
 


### PR DESCRIPTION
Screen Orientation test reported a complete failure because it was not in the list of extensions in build.yml and as such the extensions where never exercised by the JavaScript/Ruby APIs.

A local manual run of the test on an MC75 shows the tests pass when using the ruby API. But there seems to be failures when using JavaScript APIs. This is currently being analyzed.
